### PR TITLE
feat: add SSA 6.7 extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+tmp-user/
+test-results/
+

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,27 @@
+const templates = {
+  lai: 'SSA, formate este pedido LAI em 5 itens (órgão, assunto, pergunta objetiva, base legal, prazo). Texto: ‹%s›.',
+  relatorio: 'SSA, gere P&L e resumo de KPIs com meus números; destaque pendências. Texto: ‹%s›.',
+  ata: 'SSA, estruture em: presentes, pauta, falas objetivas, compromissos, prazos, anexos. Texto: ‹%s›.',
+  revise: 'Reescreva usando apenas o meu material: ‹%s›.'
+};
+
+chrome.runtime.onInstalled.addListener(() => {
+  for (const [id, template] of Object.entries(templates)) {
+    chrome.contextMenus.create({
+      id,
+      title: `SSA 6.7: ${id}`,
+      contexts: ['selection']
+    });
+  }
+});
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  const template = templates[info.menuItemId];
+  if (!template || !info.selectionText) return;
+  const text = template.replace('%s', info.selectionText);
+  chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: (t) => console.log(t),
+    args: [text]
+  });
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,10 @@
+{
+  "manifest_version": 3,
+  "name": "ForjaElo SSA 6.7",
+  "version": "1.0",
+  "description": "Context menu helpers for SSA 6.7 templates described in README.",
+  "permissions": ["contextMenus", "scripting", "activeTab"],
+  "background": {
+    "service_worker": "background.js"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,80 @@
+{
+  "name": "forjaelo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "forjaelo",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.55.0",
+        "playwright": "^1.55.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "forjaelo",
+  "version": "1.0.0",
+  "description": "Chrome extension with SSA 6.7 helpers for ForjaElo",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "devDependencies": {
+    "@playwright/test": "^1.55.0",
+    "playwright": "^1.55.0"
+  }
+}

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect, chromium } from '@playwright/test';
+test('carrega página com extensão', async () => {
+  const EXT = process.env.EXT_DIR || './extension';
+  const ctx = await chromium.launchPersistentContext('tmp-user', {
+    headless: true,
+    args: [`--disable-extensions-except=${EXT}`, `--load-extension=${EXT}`],
+  });
+  const page = await ctx.newPage();
+  await page.goto('http://example.com');
+  await expect(page).toHaveTitle(/Example/i);
+  await ctx.close();
+});


### PR DESCRIPTION
## Summary
- add chrome extension with SSA 6.7 context menu templates
- enable Playwright tests and run them against example.com

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5c7b32d788331a942ca36cbe848ce