### PR TITLE
feat: capture page text after navigation

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -25,3 +25,19 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
     args: [text]
   });
 });
+
+// Automatically log full page text after navigation completes.
+chrome.webNavigation.onCompleted.addListener(
+  ({ tabId, frameId }) => {
+    // Only run on the top frame to avoid duplicate logs.
+    if (frameId !== 0) return;
+    chrome.scripting.executeScript({
+      target: { tabId },
+      func: () => {
+        const data = document.documentElement.innerText;
+        console.log(data);
+      }
+    });
+  },
+  { url: [{ schemes: ['http', 'https'] }] }
+);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,8 @@
   "name": "ForjaElo SSA 6.7",
   "version": "1.0",
   "description": "Context menu helpers for SSA 6.7 templates described in README.",
-  "permissions": ["contextMenus", "scripting", "activeTab"],
+  "permissions": ["contextMenus", "scripting", "activeTab", "webNavigation"],
+  "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.js"
   }


### PR DESCRIPTION
## Summary
- log full page text to console whenever navigation finishes
- add required permissions for automatic page logging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c948debc83318e31ed070eabac92